### PR TITLE
fix: correção na página personas e página ferramentas

### DIFF
--- a/docs/elicitacao/personas.md
+++ b/docs/elicitacao/personas.md
@@ -19,8 +19,9 @@ Para a elaboração das personas, o criador deste artefato [Lucas Alves](https:/
 Maria Lúcia é professora de História em uma escola pública de Brasília. Aos 54 anos, divide seu tempo entre o trabalho, os cuidados com a casa e os netos. Nos últimos anos, passou a usar mais o celular para resolver questões do dia a dia, como pagar contas e acompanhar sua saúde. Apesar de se virar bem com aplicativos mais simples, ela se sente frustrada com sistemas mal organizados e com linguagem técnica demais. Quando precisa acessar os exames do marido ou agendar uma nova consulta pelo plano de saúde, ela prefere fazer tudo pelo smartphone, mas já se irritou algumas vezes com a demora no carregamento ou por não encontrar as informações facilmente. Seu desejo é simples: conseguir resolver o que precisa sem perder tempo — afinal, a rotina já é corrida o suficiente.
 
 <div style="text-align: center">
-  <img src="..\..\assets\img\personas\Persona_Maria.jpg" alt="Foto de Maria Lúcia" width="200px"/>
   <p><i>Figura 1: Representação da persona Maria Lúcia</i></p>
+  <img src="..\..\assets\img\personas\Persona_Maria.jpg" alt="Foto de Maria Lúcia" width="200px"/>
+  <p><i>THIS PERSON DOESN'T EXIST. Disponível em: https://thispersondoesnotexist.com/. Acesso em: 02 de maio de 2024.</i></p>
 </div>
 
 - **Nome:** Maria Lúcia da Silva  
@@ -42,8 +43,9 @@ Maria Lúcia é professora de História em uma escola pública de Brasília. Aos
 João Pedro é técnico administrativo em uma escola e vive uma rotina bastante estruturada. Ele **não utiliza o sistema do plano de saúde** porque prefere resolver essas questões pessoalmente ou com ajuda de terceiros. Representa um perfil que, apesar de fazer parte do público-alvo em potencial, **não é usuário do sistema** por falta de familiaridade, interesse ou confiança em soluções digitais. Sua resistência ao uso de tecnologia e preferências por métodos tradicionais fazem com que ele não se beneficie das funcionalidades oferecidas, o que o torna relevante para entender barreiras à adoção.
 
 <div style="text-align: center">
-  <img src="..\..\assets\img\personas\Persona_Joao.jpg" alt="Foto de João Pedro" width="200px"/>
   <p><i>Figura 2: Representação da persona João Pedro</i></p>
+  <img src="..\..\assets\img\personas\Persona_Joao.jpg" alt="Foto de João Pedro" width="200px"/>
+  <p><i>THIS PERSON DOESN'T EXIST. Disponível em: https://thispersondoesnotexist.com/. Acesso em: 02 de maio de 2025.</i></p>
 </div>
 
 - **Nome:** João Pedro Ramos  
@@ -65,8 +67,9 @@ João Pedro é técnico administrativo em uma escola e vive uma rotina bastante 
 Paulo Henrique trabalha na área administrativa da Secretaria de Saúde e é responsável por acompanhar dados sobre os planos de saúde oferecidos aos servidores. No dia a dia, acessa frequentemente relatórios, extratos e redes credenciadas para responder a demandas internas e encaminhar documentos a colegas. Embora tenha familiaridade com ferramentas digitais, sente frustração quando precisa navegar por muitas páginas ou realizar múltiplos cliques para chegar até uma informação básica. No escritório, utiliza um desktop com dois monitores, mas também costuma usar o smartphone fora do horário de trabalho. Já precisou enviar carteirinhas digitais por e-mail com urgência e ficou insatisfeito com a dificuldade de encontrá-las rapidamente. Para ele, produtividade e eficiência são fundamentais.
 
 <div style="text-align: center">
-  <img src="..\..\assets\img\personas\Persona_Paulo.jpg" alt="Foto de Paulo Henrique" width="200px"/>
   <p><i>Figura 3: Representação da persona Paulo Henrique</i></p>
+  <img src="..\..\assets\img\personas\Persona_Paulo.jpg" alt="Foto de Paulo Henrique" width="200px"/>
+  <p><i>THIS PERSON DOESN'T EXIST. Disponível em: https://thispersondoesnotexist.com/. Acesso em: 02 de maio de 2025.</i></p>
 </div>
 
 - **Nome:** Paulo Henrique Ferreira  

--- a/docs/planejamento/ferramentas.md
+++ b/docs/planejamento/ferramentas.md
@@ -20,7 +20,6 @@ Tabela 1: ferramentas utilizadas
 | <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Visual_Studio_Code_1.35_icon.svg/120px-Visual_Studio_Code_1.35_icon.svg.png" alt="Logo do Visual Studio Code" width="85px"> | Visual Studio Code<sup>[7](#ref7)</sup> | Edição da documentação |
 | <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/30/Google_Sheets_logo_%282014-2020%29.svg/120px-Google_Sheets_logo_%282014-2020%29.svg.png" alt="Logo do Google Planilhas" width="80px"> | Google Planilhas<sup>[8](#ref8)</sup> | Criação de planilhas de cronogramas e heatmaps |
 | <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Google_Docs_logo_%282014-2020%29.svg/120px-Google_Docs_logo_%282014-2020%29.svg.png" alt="Logo do Google Docs" width="80px"> | Google Docs<sup>[9](#ref9)</sup> | Criação de arquivos de texto para checklists, cronogramas, etc |
-| <img src="../assets/img/monday.png" alt="Logo do Monday" width="100px"> | Monday<sup>[11](#ref11)</sup> | Gerenciamento de projetos e acompanhamento de tarefas |
 | <img src="../assets/img/thispersondoesntexist.png" alt="Logo do This Person Doesn't Exist" width="100px"> | This Person Doesn't Exist<sup>[10](#ref10)</sup> | Criação de personas |
 | <img src="https://upload.wikimedia.org/wikipedia/commons/c/c2/Google_Forms_logo_%282014-2020%29.svg" alt="Logo do Google Forms" width="80px"> | Google Forms<sup>[12](#ref12)</sup> | Criação de formulários para a seleção de cargos do grupo |
 | <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/04/ChatGPT_logo.svg/120px-ChatGPT_logo.svg.png" alt="Logo do ChatGPT" width="80px"> | ChatGPT<sup>[13](#ref13)</sup> | Assistente de inteligência artificial para geração de conteúdos dos artefatos e markdown |
@@ -32,41 +31,41 @@ Autor: [Matheus de Alcântara](https://github.com/matheusdealcantara)
 
 ## Referências
 
-<a id="ref1"></a>[1] GITHUB. Disponível em: <https://github.com/>. Acesso em: 09 de abril de 2024.
+<a id="ref1"></a>[1] GITHUB. Disponível em: <https://github.com/>. Acesso em: 09 de abril de 2025.
 
-<a id="ref2"></a>[2] MICROSOFT TEAMS. Disponível em: <https://www.microsoft.com/pt-br/microsoft-teams/group-chat-software>. Acesso em: 09 de abril de 2024.
+<a id="ref2"></a>[2] MICROSOFT TEAMS. Disponível em: <https://www.microsoft.com/pt-br/microsoft-teams/group-chat-software>. Acesso em: 09 de abril de 2025.
 
-<a id="ref3"></a>[3] WHATSAPP. Disponível em: <https://www.whatsapp.com/>. Acesso em: 09 de abril de 2024.
+<a id="ref3"></a>[3] WHATSAPP. Disponível em: <https://www.whatsapp.com/>. Acesso em: 09 de abril de 2025.
 
-<a id="ref4"></a>[4] FIGMA. Disponível em: <https://www.figma.com/>. Acesso em: 09 de abril de 2024.
+<a id="ref4"></a>[4] FIGMA. Disponível em: <https://www.figma.com/>. Acesso em: 09 de abril de 2025.
 
-<a id="ref5"></a>[5] EXCALIDRAW. Disponível em: <https://excalidraw.com/>. Acesso em: 09 de abril de 2024.
+<a id="ref5"></a>[5] EXCALIDRAW. Disponível em: <https://excalidraw.com/>. Acesso em: 09 de abril de 2025.
 
-<a id="ref6"></a>[6] MKDOCS. Disponível em: <https://www.mkdocs.org/>. Acesso em: 09 de abril de 2024.
+<a id="ref6"></a>[6] MKDOCS. Disponível em: <https://www.mkdocs.org/>. Acesso em: 09 de abril de 2025.
 
-<a id="ref7"></a>[7] VISUAL STUDIO CODE. Disponível em: <https://code.visualstudio.com/>. Acesso em: 09 de abril de 2024.
+<a id="ref7"></a>[7] VISUAL STUDIO CODE. Disponível em: <https://code.visualstudio.com/>. Acesso em: 09 de abril de 2025.
 
-<a id="ref8"></a>[8] GOOGLE PLANILHAS. Disponível em: <https://www.google.com/sheets/about/>. Acesso em: 09 de abril de 2024.
+<a id="ref8"></a>[8] GOOGLE PLANILHAS. Disponível em: <https://www.google.com/sheets/about/>. Acesso em: 09 de abril de 2025.
 
-<a id="ref9"></a>[9] GOOGLE DOCS. Disponível em: <https://www.google.com/docs/about/>. Acesso em: 09 de abril de 2024.
+<a id="ref9"></a>[9] GOOGLE DOCS. Disponível em: <https://www.google.com/docs/about/>. Acesso em: 09 de abril de 2025.
 
-<a id="ref10"></a>[10] THIS PERSON DOESN'T EXIST. Disponível em: <https://thispersondoesnotexist.com/>. Acesso em: 09 de abril de 2024.
+<a id="ref10"></a>[10] THIS PERSON DOESN'T EXIST. Disponível em: <https://thispersondoesnotexist.com/>. Acesso em: 09 de abril de 2025.
 
-<a id="ref11"></a>[11] MONDAY. Disponível em: <https://monday.com/>. Acesso em: 10 de abril de 2024.
+<a id="ref11"></a>[11] MONDAY. Disponível em: <https://monday.com/>. Acesso em: 10 de abril de 2025.
 
-<a id="ref12"></a>[12] GOOGLE FORMS. Disponível em: <https://www.google.com/forms/about/>. Acesso em: 17 de abril de 2024.
+<a id="ref12"></a>[12] GOOGLE FORMS. Disponível em: <https://www.google.com/forms/about/>. Acesso em: 17 de abril de 2025.
 
-<a id="ref13"></a>[13] CHATGPT. Disponível em: <https://openai.com/chatgpt>. Acesso em: 17 de abril de 2024.
+<a id="ref13"></a>[13] CHATGPT. Disponível em: <https://openai.com/chatgpt>. Acesso em: 17 de abril de 2025.
 
-<a id="ref14"></a>[14] DEEPSEEK. Disponível em: <https://deepseek.com/>. Acesso em: 17 de abril de 2024.
+<a id="ref14"></a>[14] DEEPSEEK. Disponível em: <https://deepseek.com/>. Acesso em: 17 de abril de 2025.
 
-<a id="ref15"></a>[15] TELEGRAM. Disponível em: <https://telegram.org/>. Acesso em: 17 de abril de 2024.
+<a id="ref15"></a>[15] TELEGRAM. Disponível em: <https://telegram.org/>. Acesso em: 17 de abril de 2025.
 
 ## Histórico de Versões
 
 | Versão | Data | Descrição | Autor(es) | Revisor(es) |
 |--------|------|-----------|-----------|-------------|
-| 1.0 | 09/04/2024 | Criação da página de ferramentas | [Matheus de Alcântara](https://github.com/matheusdealcantara) | [Kaleb de Souza](https://github.com/kalebmacedo) | 
-| 1.0.1 | 10/04/2024 | Adição de novas ferramentas e correção das imagens | [Matheus de Alcântara](https://github.com/matheusdealcantara) | [Kaleb de Souza](https://github.com/kalebmacedo) |
-| 1.0.2 | 12/04/2024 | Adição de novas ferramentas e correção das imagens | [Matheus de Alcântara](https://github.com/matheusdealcantara) | [Kaleb de Souza](https://github.com/kalebmacedo) |
-| 1.0.3 | 17/04/2024 | Adição de novas ferramentas com suas imagens | [Matheus de Alcântara](https://github.com/matheusdealcantara) | [Kaleb de Souza](https://github.com/kalebmacedo) |
+| 1.0 | 09/04/2025 | Criação da página de ferramentas | [Matheus de Alcântara](https://github.com/matheusdealcantara) | [Kaleb de Souza](https://github.com/kalebmacedo) | 
+| 1.0.1 | 10/04/2025 | Adição de novas ferramentas e correção das imagens | [Matheus de Alcântara](https://github.com/matheusdealcantara) | [Kaleb de Souza](https://github.com/kalebmacedo) |
+| 1.0.2 | 12/04/2025 | Adição de novas ferramentas e correção das imagens | [Matheus de Alcântara](https://github.com/matheusdealcantara) | [Kaleb de Souza](https://github.com/kalebmacedo) |
+| 1.0.3 | 17/04/2025 | Adição de novas ferramentas com suas imagens | [Matheus de Alcântara](https://github.com/matheusdealcantara) | [Kaleb de Souza](https://github.com/kalebmacedo) |


### PR DESCRIPTION
Este *pull request* atualiza a documentação em diversos arquivos para melhorar a clareza e a precisão, especialmente nas seções de personas e ferramentas. As principais alterações incluem a adição de atribuições para imagens de personas, remoção de uma ferramenta da tabela e atualização de referências e histórico de versões para refletir o ano correto.

### **Atualizações nas personas:**
* Adicionadas atribuições às imagens das personas, indicando que foram geradas com o site "This Person Doesn't Exist", além da inclusão das datas de acesso para Maria Lúcia, João Pedro e Paulo Henrique. (`docs/elicitacao/personas.md`)

### **Atualizações nas ferramentas:**
* Removida a ferramenta `Monday` da tabela de ferramentas, pois não está mais sendo utilizada. (`docs/planejamento/ferramentas.md`)

### **Atualizações em referências e histórico de versões:**
* Atualizadas todas as datas de acesso das referências de 2024 para 2025, garantindo consistência com o ano atual. (`docs/planejamento/ferramentas.md`)
* Ajustadas as datas do histórico de versões para refletirem o ano de 2025. (`docs/planejamento/ferramentas.md`)